### PR TITLE
Feature/handle monorepo project tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,29 @@ The `--bump` flag will monotonically increase the version number.  By default, t
 Similarly, the `--minor` or `--major` argument can be given to increment the minor or major versions respectively.
 
 
+## Monorepo support
+
+There is initial support for independently versioning different components within a monorepo structure.  Support is using a convention where a component's version is prefixed with the name of the component.  For example, a monorepo may have a component named `api`.  Tags for api changes can be prefixed with the name of the component, for example, `api/1.2.3`.
+
+
+## Special formats
+
+In some cases it's necessary to output the version in different formats.  For instance, using tag-version to produce a Docker tag will break docker if a monorepo version as described above is used (docker does not like slashes in the tag).  To get a version that is docker-compatible, use the command:
+
+```
+tag-version version --format docker
+```
+
+### JSON format
+
+In the event that using the command's output for further processing within another piece of code is desires, the JSON format provides the version in a machine-usable format:
+
+```
+$ tag-version version --format json
+{"version_triple": "0.1.0", "major": "0", "minor": "1", "patch": "0", "prefix": "", "prefix_separator": "", "tags": "rc5-1-g2e13a96-feature--handle-monorepo-project-tag", "prerelease": "rc5-1-g2e13a96-feature--handle-monorepo-project-tag", "prerelease_separator": "", "build": ""}
+```
+
+
 ### Help text
 
 ```

--- a/setup.py
+++ b/setup.py
@@ -11,19 +11,15 @@ if not SCRIPT_DIR:
     SCRIPT_DIR = os.getcwd()
 
 
-setup(name='tag-version',
-      version='0.0.0',
-      description='semantic versioned git tags',
-      author='OpenSlate',
-      author_email='code@openslate.com',
-      url='https://github.com/openslate/tag-version',
-      package_dir={'': 'src'},
-      packages=['tagversion'],
-      install_requires=[
-        'sh',
-      ],
-      entry_points={
-          'console_scripts': [
-              'tag-version = tagversion.entrypoints:main'
-          ]
-      },)
+setup(
+    name="tag-version",
+    version="0.0.0",
+    description="semantic versioned git tags",
+    author="OpenSlate",
+    author_email="code@openslate.com",
+    url="https://github.com/openslate/tag-version",
+    package_dir={"": "src"},
+    packages=["tagversion"],
+    install_requires=["sh"],
+    entry_points={"console_scripts": ["tag-version = tagversion.entrypoints:main"]},
+)

--- a/src/tagversion/argparse.py
+++ b/src/tagversion/argparse.py
@@ -19,7 +19,7 @@ class ArgumentParser(argparse.ArgumentParser):
         """
         subparser_found = False
         for arg in sys.argv[1:]:
-            if arg in ['-h', '--help']:  # global help if no subparser
+            if arg in ["-h", "--help"]:  # global help if no subparser
                 break
         else:
             for x in self._subparsers._actions:
@@ -36,7 +36,13 @@ class ArgumentParser(argparse.ArgumentParser):
                 else:
                     args.insert(0, name)
 
-    def parse_args(self, args=None, namespace=None, default_subparser=None, default_subparser_args=None):
+    def parse_args(
+        self,
+        args=None,
+        namespace=None,
+        default_subparser=None,
+        default_subparser_args=None,
+    ):
         if default_subparser:
             self.set_default_subparser(default_subparser, args=default_subparser_args)
 

--- a/src/tagversion/entrypoints.py
+++ b/src/tagversion/entrypoints.py
@@ -9,19 +9,19 @@ from tagversion.argparse import ArgumentParser
 from tagversion.git import GitVersion
 from tagversion.write import WriteFile
 
-LOG_LEVEL = os.environ.get('LOG_LEVEL', 'warning')
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "warning")
 
 
 def main():
     logging.basicConfig(level=getattr(logging, LOG_LEVEL.upper()))
 
     parser = ArgumentParser()
-    subcommand = parser.add_subparsers(dest='subcommand')
+    subcommand = parser.add_subparsers(dest="subcommand")
 
     GitVersion.setup_subparser(subcommand)
     WriteFile.setup_subparser(subcommand)
 
-    args = parser.parse_args(default_subparser='version')
+    args = parser.parse_args(default_subparser="version")
 
     command = args.cls(args)
     sys.exit(command.run())

--- a/src/tagversion/exceptions.py
+++ b/src/tagversion/exceptions.py
@@ -2,5 +2,9 @@ class BranchError(Exception):
     pass
 
 
+class PrereleaseError(Exception):
+    pass
+
+
 class VersionError(Exception):
     pass

--- a/src/tagversion/git.py
+++ b/src/tagversion/git.py
@@ -307,7 +307,7 @@ class GitVersion(object):
         return next_version.split(".")
 
     def bump(self, version: "Version" = None) -> "Version":
-        current_version = version.copy() or self.version
+        current_version = (version and version.copy()) or self.version
 
         if current_version is None:
             print_error("No commits found - please commit something before bumping")

--- a/src/tagversion/git.py
+++ b/src/tagversion/git.py
@@ -194,6 +194,11 @@ class GitVersion(object):
             "--prefix", action="store", help="add the given prefix to the version"
         )
         parser.add_argument(
+            "--prefix-separator",
+            action="store",
+            help="change the found separator to this one",
+        )
+        parser.add_argument(
             "--minor",
             action="store_true",
             help="bump the minor version and reset patch back to 0",
@@ -424,8 +429,10 @@ class GitVersion(object):
     def stringify(self, new_version: "Version", format=None):
         format = format or self.args.format
 
-        prefix = self.args.prefix
-        if prefix:
-            new_version.prefix = prefix
+        # customize the version object as specified by the arguments passed to the command
+        for attr in ("prefix", "prefix_separator"):
+            value = getattr(self.args, attr)
+            if value:
+                setattr(new_version, attr, value)
 
         return new_version.stringify(format=format, args=self.args)

--- a/src/tagversion/git.py
+++ b/src/tagversion/git.py
@@ -14,28 +14,6 @@ import sys
 from .exceptions import BranchError, VersionError
 from .version import Version
 
-"""
-    Uses a slightly modified version of this regex
-    https://regex101.com/r/E0iVVS/2
-"""
-SEMVER_RE = re.compile(
-    """
-                       ^(?P<VersionTripple>
-                            (?P<Major>0|[1-9][0-9]*)\.
-                            (?P<Minor>0|[1-9][0-9]*)\.
-                            (?P<Patch>0|[1-9][0-9]*)
-                        ){1}
-                        (?P<Tags>(?:\-
-                            (?P<Prerelease>
-                                (?:(?=[0]{1}[0-9A-Za-z-]{0})(?:[0]{1})|(?=[1-9]{1}[0-9]*[A-Za-z]{0})(?:[0-9]+)|(?=[0-9]*[A-Za-z-]+[0-9A-Za-z-]*)(?:[0-9A-Za-z-]+)){1}(?:\.(?=[0]{1}[0-9A-Za-z-]{0})(?:[0]{1})|\.(?=[1-9]{1}[0-9]*[A-Za-z]{0})(?:[0-9]+)|\.(?=[0-9]*[A-Za-z-]+[0-9A-Za-z-]*)(?:[0-9A-Za-z-]+))*){1}
-                            ){0,1}(?:\+
-                            (?P<Build>
-                                (?:[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*
-                            ))
-                        ){0,1})$
-                       """,
-    re.VERBOSE,
-)
 
 RC_RE = re.compile(r"(?P<full_version>(?P<stable>.*)rc(?P<rc_number>\d+)).*")
 
@@ -61,10 +39,6 @@ def is_calver(calver_version, calver_format):
         return False
     else:
         return True
-
-
-def is_semver(semver_version):
-    return SEMVER_RE.match(semver_version) is not None
 
 
 def is_rc(version):
@@ -155,7 +129,9 @@ class GitVersion(object):
 
     @property
     def is_semver(self):
-        return is_semver(str(self.version))
+        version = self.version
+
+        return version and version.is_semver
 
     @property
     def is_rc(self):

--- a/src/tagversion/git.py
+++ b/src/tagversion/git.py
@@ -186,7 +186,7 @@ class GitVersion(object):
             "--format",
             action="store",
             default="default",
-            help="print version as a specific format (currently supports 'default' and 'docker')",
+            help="print version as a specific format (currently supports 'default', 'docker', 'json', and 'sugar')",
         )
         parser.add_argument(
             "--patch",

--- a/src/tagversion/git.py
+++ b/src/tagversion/git.py
@@ -65,6 +65,7 @@ class GitVersion(object):
             lines = command.stdout.decode("utf8").strip().splitlines()
             branch = lines[0].strip()
 
+            # clean out control characters that may be present in `git` command output
             color_marker_idx = branch.find("\x1b")
             if color_marker_idx >= 0:
                 self.logger.warning(

--- a/src/tagversion/git.py
+++ b/src/tagversion/git.py
@@ -14,7 +14,7 @@ import sys
 from .exceptions import BranchError, VersionError
 from .version import Version
 
-
+# TODO: this implementation and its dependents should go away in favor of the version module.
 RC_RE = re.compile(r"(?P<full_version>(?P<stable>.*)rc(?P<rc_number>\d+)).*")
 
 INITIAL_VERSION = Version.parse("0.0.0")

--- a/src/tagversion/git.py
+++ b/src/tagversion/git.py
@@ -148,6 +148,10 @@ class GitVersion(object):
         if version_s:
             version = Version.parse(version_s)
 
+            build = getattr(self.args, "build", None)
+            if build:
+                version.build = build
+
         return version
 
     @classmethod

--- a/src/tagversion/version.py
+++ b/src/tagversion/version.py
@@ -189,18 +189,6 @@ class Version:
 
         return version
 
-    def stringify_docker(self, args: object = None) -> str:
-        version = self._get_semver()
-
-        if self.prerelease:
-            version = f"{version}{self.prerelease_separator}{self.prerelease}"
-
-        display_prefix = args.display_prefix if args else None
-        if display_prefix and self.prefix:
-            version = f"{version}-{self.prefix}"
-
-        return version
-
     def stringify_json(self, args: object = None) -> str:
         """Returns the parsed version as a JSON string"""
         return json.dumps(self.__dict__)

--- a/src/tagversion/version.py
+++ b/src/tagversion/version.py
@@ -1,0 +1,75 @@
+import re
+
+from .exceptions import VersionError
+
+'''
+    Uses a slightly modified version of this regex
+    https://regex101.com/r/E0iVVS/2
+'''
+SEMVER_RE = re.compile('''
+                       ^(?P<prefix>.*/)?
+                       (?P<version_triple>
+                            (?P<major>0|[1-9][0-9]*)\.
+                            (?P<minor>0|[1-9][0-9]*)\.?
+                            (?P<patch>0|[1-9][0-9]*)?
+                        ){1}
+                        (?P<tags>(?:\-?
+                            (?P<prerelease>
+                                (?:(?=[0]{1}[0-9A-Za-z-]{0})(?:[0]{1})|(?=[1-9]{1}[0-9]*[A-Za-z]{0})(?:[0-9]+)|(?=[0-9]*[A-Za-z-]+[0-9A-Za-z-]*)(?:[0-9A-Za-z-]+)){1}(?:\.(?=[0]{1}[0-9A-Za-z-]{0})(?:[0]{1})|\.(?=[1-9]{1}[0-9]*[A-Za-z]{0})(?:[0-9]+)|\.(?=[0-9]*[A-Za-z-]+[0-9A-Za-z-]*)(?:[0-9A-Za-z-]+))*){1}
+                            ){0,1}(?:\+
+                            (?P<build>
+                                (?:[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*
+                            ))
+                        ){0,1})$
+                       ''', re.VERBOSE)
+
+
+class Version:
+    def __init__(self, major="0", minor="0", patch="0", prefix=None, prerelease=None, tags=None, build=None, version_triple=None):
+        """
+        Args:
+            version_triple: the dotted version number, e.g. '1.2.3'
+            major: the first number in the triple, e.g. '1'
+            minor: the second number in the triple, e.g. '2'
+            patch: the third number in the triple, e.g. '3'
+            prefix: the prefix prior to the version triple
+            tags:
+            prerelease: None
+            build: None
+        """
+        self.version_triple = version_triple
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+        self.prefix = prefix
+        self.tags = tags
+        self.prerelease = prerelease
+        self.build = build
+
+    def __eq__(self, other):
+        return str(self) == str(other)
+
+    def __repr__(self):
+        return f"<Version: {self}>"
+
+    def __str__(self):
+        return self.stringify()
+
+    @classmethod
+    def parse(cls, version_s: str) -> 'Version':
+        matches = SEMVER_RE.match(version_s)
+        if not matches:
+            raise VersionError(f"unable to parse version_s={version_s}")
+
+        return Version(**matches.groupdict())
+
+    def stringify(self):
+        version = f"{self.major}.{self.minor}.{self.patch}"
+
+        if self.prefix:
+            version = f"{self.prefix}{version}"
+
+        if self.prerelease:
+            version = f"{version}{self.prerelease}"
+
+        return version

--- a/src/tagversion/version.py
+++ b/src/tagversion/version.py
@@ -2,11 +2,12 @@ import re
 
 from .exceptions import VersionError
 
-'''
+"""
     Uses a slightly modified version of this regex
     https://regex101.com/r/E0iVVS/2
-'''
-SEMVER_RE = re.compile('''
+"""
+SEMVER_RE = re.compile(
+    """
                        ^(?P<prefix>.*/)?
                        (?P<version_triple>
                             (?P<major>0|[1-9][0-9]*)\.
@@ -21,11 +22,23 @@ SEMVER_RE = re.compile('''
                                 (?:[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*
                             ))
                         ){0,1})$
-                       ''', re.VERBOSE)
+                       """,
+    re.VERBOSE,
+)
 
 
 class Version:
-    def __init__(self, major="0", minor="0", patch="0", prefix=None, prerelease=None, tags=None, build=None, version_triple=None):
+    def __init__(
+        self,
+        major="0",
+        minor="0",
+        patch="0",
+        prefix=None,
+        prerelease=None,
+        tags=None,
+        build=None,
+        version_triple=None,
+    ):
         """
         Args:
             version_triple: the dotted version number, e.g. '1.2.3'
@@ -56,7 +69,7 @@ class Version:
         return self.stringify()
 
     @classmethod
-    def parse(cls, version_s: str) -> 'Version':
+    def parse(cls, version_s: str) -> "Version":
         matches = SEMVER_RE.match(version_s)
         if not matches:
             raise VersionError(f"unable to parse version_s={version_s}")

--- a/src/tagversion/version.py
+++ b/src/tagversion/version.py
@@ -76,10 +76,10 @@ class Version:
 
         return Version(**matches.groupdict())
 
-    def stringify(self):
+    def stringify(self, display_prefix: bool = True):
         version = f"{self.major}.{self.minor}.{self.patch}"
 
-        if self.prefix:
+        if display_prefix and self.prefix:
             version = f"{self.prefix}{version}"
 
         if self.prerelease:

--- a/src/tagversion/version.py
+++ b/src/tagversion/version.py
@@ -196,9 +196,8 @@ class Version:
     def stringify_sugar(self, args: object = None):
         version = self._get_semver()
 
-        build = args.build if args else None
-        if build:
-            version = f"{version}-{build}"
+        if self.build:
+            version = f"{version}-{self.build}"
 
         if self.prerelease:
             version = f"{version}{self.prerelease_separator or ''}{self.prerelease}"

--- a/src/tagversion/version.py
+++ b/src/tagversion/version.py
@@ -189,6 +189,20 @@ class Version:
 
         return version
 
+    def stringify_docker(self, args: object = None) -> str:
+        version = self._get_semver()
+        prefix_separator = "-"
+
+        # replace the slash separator with
+        display_prefix = args.display_prefix if args else True
+        if display_prefix and self.prefix:
+            version = f"{self.prefix}{prefix_separator}{version}"
+
+        if self.prerelease:
+            version = f"{version}{self.prerelease_separator}{self.prerelease}"
+
+        return version
+
     def stringify_json(self, args: object = None) -> str:
         """Returns the parsed version as a JSON string"""
         return json.dumps(self.__dict__)

--- a/src/tagversion/version.py
+++ b/src/tagversion/version.py
@@ -1,29 +1,34 @@
+import json
 import re
 
 from .exceptions import PrereleaseError, VersionError
 
 """
-    Uses a slightly modified version of this regex
-    https://regex101.com/r/E0iVVS/2
+Uses a slightly modified version of this regex
+https://regex101.com/r/E0iVVS/2
+
+copied to:
+
+https://regex101.com/r/NpbTSw/3
 """
 SEMVER_RE = re.compile(
     r"""
-                       ^(?P<prefix>.*/)?
-                       (?P<version_triple>
-                            (?P<major>0|[1-9][0-9]*)\.
-                            (?P<minor>0|[1-9][0-9]*)\.?
-                            (?P<patch>0|[1-9][0-9]*)?
-                        ){0,1}
-                        (?P<tags>(?:
-                            (?P<prereleasedash>\-?)
-                            (?P<prerelease>
-                                (?:(?=[0]{1}[0-9A-Za-z-]{0})(?:[0]{1})|(?=[1-9]{1}[0-9]*[A-Za-z]{0})(?:[0-9]+)|(?=[0-9]*[A-Za-z-]+[0-9A-Za-z-]*)(?:[0-9A-Za-z-]+)){1}(?:\.(?=[0]{1}[0-9A-Za-z-]{0})(?:[0]{1})|\.(?=[1-9]{1}[0-9]*[A-Za-z]{0})(?:[0-9]+)|\.(?=[0-9]*[A-Za-z-]+[0-9A-Za-z-]*)(?:[0-9A-Za-z-]+))*){1}
-                            ){0,1}(?:\+
-                            (?P<build>
-                                (?:[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*
-                            ))
-                        ){0,1})$
-                       """,
+    ^(?:(?P<prefix>.*)(?P<prefix_separator>.*/))?
+    (?P<version_triple>
+        (?P<major>0|[1-9][0-9]*)\.
+        (?P<minor>0|[1-9][0-9]*)\.?
+        (?P<patch>0|[1-9][0-9]*)?
+    ){0,1}
+    (?P<tags>(?:
+        (?P<prerelease_separator>\-?)
+        (?P<prerelease>
+            (?:(?=[0]{1}[0-9A-Za-z-]{0})(?:[0]{1})|(?=[1-9]{1}[0-9]*[A-Za-z]{0})(?:[0-9]+)|(?=[0-9]*[A-Za-z-]+[0-9A-Za-z-]*)(?:[0-9A-Za-z-]+)){1}(?:\.(?=[0]{1}[0-9A-Za-z-]{0})(?:[0]{1})|\.(?=[1-9]{1}[0-9]*[A-Za-z]{0})(?:[0-9]+)|\.(?=[0-9]*[A-Za-z-]+[0-9A-Za-z-]*)(?:[0-9A-Za-z-]+))*){1}
+        ){0,1}(?:\+
+        (?P<build>
+            (?:[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*
+        ))
+    ){0,1})$
+    """,
     re.VERBOSE,
 )
 
@@ -39,8 +44,9 @@ class Version:
         minor="0",
         patch="0",
         prefix=None,
+        prefix_separator=None,
         prerelease=None,
-        prereleasedash=None,
+        prerelease_separator=None,
         tags=None,
         build=None,
         version_triple=None,
@@ -60,11 +66,12 @@ class Version:
         self.major = major
         self.minor = minor
         self.patch = patch
-        self.prefix = prefix
+        self.prefix = prefix or ""
+        self.prefix_separator = prefix_separator or ""
         self.tags = tags
-        self.prerelease = prerelease
-        self.prereleasedash = prereleasedash
-        self.build = build
+        self.prerelease = prerelease or ""
+        self.prerelease_separator = prerelease_separator or ""
+        self.build = build or ""
 
     def __eq__(self, other):
         return str(self) == str(other)
@@ -99,12 +106,12 @@ class Version:
 
                 self.prerelease = f"rc{int(matches.group('rc_number'))+1}"
             else:
-                self.prereleasedash = None
+                self.prerelease_separator = ""
                 self.prerelease = "rc1"
 
         # when everything is False and the version is a prerelease, drop the prerelease
         if self.prerelease and not bump_prerelease:
-            self.prereleasedash = None
+            self.prerelease_separator = ""
             self.prerelease = None
 
     def copy(self) -> "Version":
@@ -164,6 +171,6 @@ class Version:
             version = f"{self.prefix}{version}"
 
         if self.prerelease:
-            version = f"{version}{self.prereleasedash or ''}{self.prerelease}"
+            version = f"{version}{self.prerelease_separator or ''}{self.prerelease}"
 
         return version

--- a/src/tagversion/write.py
+++ b/src/tagversion/write.py
@@ -55,7 +55,7 @@ class WriteFile(object):
                 matches = version_re.match(content)
                 if matches:
                     buf.write(matches.group("start"))
-                    buf.write(version)
+                    buf.write(version.stringify())
 
                     content = matches.group("content")
                 else:

--- a/src/tagversion/write.py
+++ b/src/tagversion/write.py
@@ -9,7 +9,8 @@ except ImportError:
 
 from .git import GitVersion
 
-DEFAULT_VERSION_PATTERN = r'(?P<start>.*?){{\s*version\s*}}(?P<content>.*)'
+DEFAULT_VERSION_PATTERN = r"(?P<start>.*?){{\s*version\s*}}(?P<content>.*)"
+
 
 def get_version_re(pattern):
     return re.compile(pattern, re.DOTALL)
@@ -19,43 +20,47 @@ class WriteFile(object):
     """
     Write version into a file
     """
+
     def __init__(self, args):
         self.args = args
 
     @classmethod
     def setup_subparser(cls, subcommand):
-        parser = subcommand.add_parser('write', help=cls.__doc__)
+        parser = subcommand.add_parser("write", help=cls.__doc__)
 
         parser.set_defaults(cls=cls)
         parser.add_argument(
-            '--pattern', default=DEFAULT_VERSION_PATTERN,
-            help='a regex pattern to search and replace with the version, default "{}"'.format(DEFAULT_VERSION_PATTERN)
+            "--pattern",
+            default=DEFAULT_VERSION_PATTERN,
+            help='a regex pattern to search and replace with the version, default "{}"'.format(
+                DEFAULT_VERSION_PATTERN
+            ),
         )
         parser.add_argument(
-            '--no-branch', action='store_false', dest='branch',
-            help='do not append branch to the version when current commit is not tagged'
+            "--no-branch",
+            action="store_false",
+            dest="branch",
+            help="do not append branch to the version when current commit is not tagged",
         )
-        parser.add_argument(
-            'path', help='path to the file to write version in'
-        )
+        parser.add_argument("path", help="path to the file to write version in")
 
     def run(self):
         version = GitVersion(self.args).version
         version_re = get_version_re(self.args.pattern)
 
         buf = StringIO()
-        with open(self.args.path, 'r') as fh:
+        with open(self.args.path, "r") as fh:
             content = fh.read()
             while content:
                 matches = version_re.match(content)
                 if matches:
-                    buf.write(matches.group('start'))
+                    buf.write(matches.group("start"))
                     buf.write(version)
 
-                    content = matches.group('content')
+                    content = matches.group("content")
                 else:
                     buf.write(content)
                     break
 
-        with open(self.args.path, 'w') as fh:
+        with open(self.args.path, "w") as fh:
             fh.write(buf.getvalue())

--- a/src/tests/test_git.py
+++ b/src/tests/test_git.py
@@ -1,15 +1,23 @@
 from unittest import TestCase, mock
 
 from tagversion.git import GitVersion, is_rc
+from tagversion.version import Version
 
 RC_VERSION = "0.1.28rc1-1-g4fafe09-feature--skip-prefix-rows"
 
 
 @mock.patch("tagversion.git.sh")
+@mock.patch("tagversion.git.GitVersion.get_git_tag_version")
 class GitTestCase(TestCase):
     def _get_args(self, **kwargs):
         args = mock.Mock(
-            calver=False, major=False, minor=False, patch=False, prefix=None, rc=False
+            calver=False,
+            major=False,
+            minor=False,
+            patch=False,
+            prefix=None,
+            rc=False,
+            display_prefix=False,
         )
 
         for k, v in kwargs.items():
@@ -18,7 +26,7 @@ class GitTestCase(TestCase):
         return args
 
     def _setup_version(self, *mocks, version=RC_VERSION):
-        version_mock = mocks[0]
+        version_mock = mocks[-2]
         version_mock.return_value = version
 
         return version_mock
@@ -27,7 +35,6 @@ class GitTestCase(TestCase):
         sh_mock = mocks[-1]
         sh_mock.git.return_value.stdout = version.encode("utf8")
 
-    @mock.patch("tagversion.git.GitVersion.version", new_callable=mock.PropertyMock)
     def test_bump_no_tag(self, *mocks):
         """
         Ensures bumping when there is no tag produces 0.0.1
@@ -40,33 +47,17 @@ class GitTestCase(TestCase):
 
         new_version = git_version.bump()
 
-        self.assertEquals([0, 0, 1], new_version)
+        self.assertEquals("0.0.1", str(new_version))
 
-    @mock.patch("tagversion.git.GitVersion.version", new_callable=mock.PropertyMock)
-    def test_bump_to_rc(self, *mocks):
-        """
-        Ensures bumping to an RC properly revs version
-        """
-        version_mock = self._setup_version(
-            *mocks, version="0.1.27-16-g5befeb2-feature--skip-prefix-rows"
-        )
-
-        args = self._get_args(patch=True, rc=True)
-
-        git_version = GitVersion(args)
-
-        new_version = git_version.bump()
-
-        self.assertEquals([0, 1, "28rc1"], new_version)
-
-    @mock.patch("tagversion.git.GitVersion.version", new_callable=mock.PropertyMock)
     def test_bump_rc(self, *mocks):
         """
         Ensures running bump results in a stable, non-rc, release
         """
-        version_mock = self._setup_version(*mocks)
+        version_mock = self._setup_version(
+            *mocks, version="0.1.28rc1-1-g4fafe09-feature--skip-prefix-rows"
+        )
 
-        args = self._get_args(patch=True)
+        args = self._get_args()
 
         git_version = GitVersion(args)
 
@@ -74,16 +65,15 @@ class GitTestCase(TestCase):
 
         new_version = git_version.bump()
 
-        self.assertEquals([0, 1, 28], new_version)
+        self.assertEquals("0.1.28", str(new_version))
 
-    @mock.patch("tagversion.git.GitVersion.version", new_callable=mock.PropertyMock)
     def test_bump_rc_to_stable(self, *mocks):
         """
         Ensures running bump results in a stable, non-rc, release
         """
         version_mock = self._setup_version(*mocks, version="0.1.28rc2")
 
-        args = self._get_args(patch=True)
+        args = self._get_args()
 
         git_version = GitVersion(args)
 
@@ -91,16 +81,15 @@ class GitTestCase(TestCase):
 
         new_version = git_version.bump()
 
-        self.assertEquals([0, 1, 28], new_version)
+        self.assertEquals("0.1.28", str(new_version))
 
-    @mock.patch("tagversion.git.GitVersion.version", new_callable=mock.PropertyMock)
     def test_bump_rev_rc(self, *mocks):
         """
         Ensures running bump --rc on an RC results in a proper rc tag
         """
         version_mock = self._setup_version(*mocks)
 
-        args = mock.Mock(rc=True)
+        args = self._get_args(rc=True)
 
         git_version = GitVersion(args)
 
@@ -108,7 +97,7 @@ class GitTestCase(TestCase):
 
         new_version = git_version.bump()
 
-        self.assertEquals(["0", "1", "28rc2"], new_version)
+        self.assertEquals("0.1.28rc2", new_version)
 
     def test_get_next_rc_version(self, *mocks):
         """
@@ -118,37 +107,24 @@ class GitTestCase(TestCase):
 
         self.assertEquals(["0", "1", "28rc2"], next_version)
 
-    @mock.patch("tagversion.git.GitVersion.version", new_callable=mock.PropertyMock)
     def test_is_rc(self, *mocks):
         """
         Ensures RC is properly detected
         """
         self.assertEquals(True, is_rc(RC_VERSION))
 
-    def test_remove_project_prefix(self, *mocks):
-        """
-        When getting a tag with a prefix, remove the prefix
-        """
-        version_mock = self._setup_git_describe(*mocks, version="TestModule/0.0.1")
-
-        args = self._get_args()
-
-        git_version = GitVersion(args)
-
-        self.assertEquals("0.0.1", git_version.version)
-
     def test_bump_project_prefix(self, *mocks):
         """
-        When getting a tag with a prefix, remove the prefix
+        When bumping a tag with a prefix, only return the version
         """
-        version_mock = self._setup_git_describe(
+        version_mock = self._setup_version(
             *mocks, version="TestModule/0.0.1-16-g5befeb2"
         )
 
-        args = self._get_args(patch=True, prefix="TestModule/")
+        args = self._get_args(patch=True)
 
         git_version = GitVersion(args)
         new_version = git_version.bump()
         new_version_s = git_version.stringify(new_version)
 
-        self.assertEquals("TestModule/0.0.2", new_version_s)
+        self.assertEquals("0.0.2", new_version_s)

--- a/src/tests/test_git.py
+++ b/src/tests/test_git.py
@@ -2,13 +2,15 @@ from unittest import TestCase, mock
 
 from tagversion.git import GitVersion, is_rc
 
-RC_VERSION = '0.1.28rc1-1-g4fafe09-feature--skip-prefix-rows'
+RC_VERSION = "0.1.28rc1-1-g4fafe09-feature--skip-prefix-rows"
 
 
-@mock.patch('tagversion.git.sh')
+@mock.patch("tagversion.git.sh")
 class GitTestCase(TestCase):
     def _get_args(self, **kwargs):
-        args = mock.Mock(calver=False, major=False, minor=False, patch=False, prefix=None, rc=False)
+        args = mock.Mock(
+            calver=False, major=False, minor=False, patch=False, prefix=None, rc=False
+        )
 
         for k, v in kwargs.items():
             setattr(args, k, v)
@@ -23,14 +25,14 @@ class GitTestCase(TestCase):
 
     def _setup_git_describe(self, *mocks, version: str) -> None:
         sh_mock = mocks[-1]
-        sh_mock.git.return_value.stdout = version.encode('utf8')
+        sh_mock.git.return_value.stdout = version.encode("utf8")
 
-    @mock.patch('tagversion.git.GitVersion.version', new_callable=mock.PropertyMock)
+    @mock.patch("tagversion.git.GitVersion.version", new_callable=mock.PropertyMock)
     def test_bump_no_tag(self, *mocks):
         """
         Ensures bumping when there is no tag produces 0.0.1
         """
-        version_mock = self._setup_version(*mocks, version='000000-master')
+        version_mock = self._setup_version(*mocks, version="000000-master")
 
         args = self._get_args(patch=True)
 
@@ -40,13 +42,14 @@ class GitTestCase(TestCase):
 
         self.assertEquals([0, 0, 1], new_version)
 
-
-    @mock.patch('tagversion.git.GitVersion.version', new_callable=mock.PropertyMock)
+    @mock.patch("tagversion.git.GitVersion.version", new_callable=mock.PropertyMock)
     def test_bump_to_rc(self, *mocks):
         """
         Ensures bumping to an RC properly revs version
         """
-        version_mock = self._setup_version(*mocks, version='0.1.27-16-g5befeb2-feature--skip-prefix-rows')
+        version_mock = self._setup_version(
+            *mocks, version="0.1.27-16-g5befeb2-feature--skip-prefix-rows"
+        )
 
         args = self._get_args(patch=True, rc=True)
 
@@ -54,9 +57,9 @@ class GitTestCase(TestCase):
 
         new_version = git_version.bump()
 
-        self.assertEquals([0, 1, '28rc1'], new_version)
+        self.assertEquals([0, 1, "28rc1"], new_version)
 
-    @mock.patch('tagversion.git.GitVersion.version', new_callable=mock.PropertyMock)
+    @mock.patch("tagversion.git.GitVersion.version", new_callable=mock.PropertyMock)
     def test_bump_rc(self, *mocks):
         """
         Ensures running bump results in a stable, non-rc, release
@@ -73,12 +76,12 @@ class GitTestCase(TestCase):
 
         self.assertEquals([0, 1, 28], new_version)
 
-    @mock.patch('tagversion.git.GitVersion.version', new_callable=mock.PropertyMock)
+    @mock.patch("tagversion.git.GitVersion.version", new_callable=mock.PropertyMock)
     def test_bump_rc_to_stable(self, *mocks):
         """
         Ensures running bump results in a stable, non-rc, release
         """
-        version_mock = self._setup_version(*mocks, version='0.1.28rc2')
+        version_mock = self._setup_version(*mocks, version="0.1.28rc2")
 
         args = self._get_args(patch=True)
 
@@ -90,7 +93,7 @@ class GitTestCase(TestCase):
 
         self.assertEquals([0, 1, 28], new_version)
 
-    @mock.patch('tagversion.git.GitVersion.version', new_callable=mock.PropertyMock)
+    @mock.patch("tagversion.git.GitVersion.version", new_callable=mock.PropertyMock)
     def test_bump_rev_rc(self, *mocks):
         """
         Ensures running bump --rc on an RC results in a proper rc tag
@@ -105,7 +108,7 @@ class GitTestCase(TestCase):
 
         new_version = git_version.bump()
 
-        self.assertEquals(['0', '1', '28rc2'], new_version)
+        self.assertEquals(["0", "1", "28rc2"], new_version)
 
     def test_get_next_rc_version(self, *mocks):
         """
@@ -113,9 +116,9 @@ class GitTestCase(TestCase):
         """
         next_version = GitVersion.get_next_rc_version(RC_VERSION)
 
-        self.assertEquals(['0', '1', '28rc2'], next_version)
+        self.assertEquals(["0", "1", "28rc2"], next_version)
 
-    @mock.patch('tagversion.git.GitVersion.version', new_callable=mock.PropertyMock)
+    @mock.patch("tagversion.git.GitVersion.version", new_callable=mock.PropertyMock)
     def test_is_rc(self, *mocks):
         """
         Ensures RC is properly detected
@@ -126,24 +129,26 @@ class GitTestCase(TestCase):
         """
         When getting a tag with a prefix, remove the prefix
         """
-        version_mock = self._setup_git_describe(*mocks, version='TestModule/0.0.1')
+        version_mock = self._setup_git_describe(*mocks, version="TestModule/0.0.1")
 
         args = self._get_args()
 
         git_version = GitVersion(args)
 
-        self.assertEquals('0.0.1', git_version.version)
+        self.assertEquals("0.0.1", git_version.version)
 
     def test_bump_project_prefix(self, *mocks):
         """
         When getting a tag with a prefix, remove the prefix
         """
-        version_mock = self._setup_git_describe(*mocks, version='TestModule/0.0.1-16-g5befeb2')
+        version_mock = self._setup_git_describe(
+            *mocks, version="TestModule/0.0.1-16-g5befeb2"
+        )
 
-        args = self._get_args(patch=True, prefix='TestModule/')
+        args = self._get_args(patch=True, prefix="TestModule/")
 
         git_version = GitVersion(args)
         new_version = git_version.bump()
         new_version_s = git_version.stringify(new_version)
 
-        self.assertEquals('TestModule/0.0.2', new_version_s)
+        self.assertEquals("TestModule/0.0.2", new_version_s)

--- a/src/tests/test_git.py
+++ b/src/tests/test_git.py
@@ -16,6 +16,7 @@ class GitTestCase(TestCase):
             minor=False,
             patch=False,
             prefix=None,
+            prefix_separator=None,
             rc=False,
             display_prefix=True,
             format="default",
@@ -158,17 +159,17 @@ class GitTestCase(TestCase):
         self.assertEquals("2", new_version.minor)
         self.assertEquals("3", new_version.patch)
 
-    def test_stringify_docker(self, *mocks):
+    def test_stringify_change_prefix_separator(self, *mocks):
         """
-        ;prefix version is properly converted to a docker tag string
+        Ensure the prefix separator can be changed
         """
         version_mock = self._setup_version(
             *mocks, version="TestModule/0.0.1-16-g5befeb2"
         )
 
-        args = self._get_args(format="docker", display_prefix=True)
+        args = self._get_args(prefix_separator="-")
 
         git_version = GitVersion(args)
         new_version_s = git_version.stringify(git_version.version)
 
-        self.assertEquals("0.0.1-16-g5befeb2-TestModule", new_version_s)
+        self.assertEquals("TestModule-0.0.1-16-g5befeb2", new_version_s)

--- a/src/tests/test_version.py
+++ b/src/tests/test_version.py
@@ -4,6 +4,150 @@ from tagversion.version import Version
 
 
 class VersionTestCase(TestCase):
+    def test_bump_major(self, *mocks):
+        """Ensure major is bumped"""
+
+        version = Version.parse("0.0.0")
+        version.bump(bump_major=True)
+
+        self.assertEquals(
+            "1.0.0",
+            str(version),
+        )
+
+    def test_bump_minor(self, *mocks):
+        """Ensure minor is bumped"""
+
+        version = Version.parse("0.0.0")
+        version.bump(bump_minor=True)
+
+        self.assertEquals(
+            "0.1.0",
+            str(version),
+        )
+
+    def test_bump_patch(self, *mocks):
+        """Ensure patch is bumped"""
+
+        version = Version.parse("0.0.0")
+        version.bump(bump_patch=True)
+
+        self.assertEquals(
+            "0.0.1",
+            str(version),
+        )
+
+    def test_bump_new_prerelease(self, *mocks):
+        """Ensure prerelease is added"""
+
+        version = Version.parse("0.0.1")
+        version.bump(bump_prerelease=True)
+
+        self.assertEquals(
+            "0.0.1rc1",
+            str(version),
+        )
+
+    def test_bump_prerelease(self, *mocks):
+        """Ensure prerelease is bumped"""
+
+        version = Version.parse("0.0.1rc1")
+        version.bump(bump_prerelease=True)
+
+        self.assertEquals(
+            "0.0.1rc2",
+            str(version),
+        )
+
+    def test_bump_to_prerelease(self, *mocks):
+        """Ensure patch and prerelease is set"""
+
+        version = Version.parse("0.1.27-16-g5befeb2-feature--skip-prefix-rows")
+        version.bump(bump_patch=True, bump_prerelease=True)
+
+        self.assertEquals(
+            "0.1.28rc1",
+            str(version),
+        )
+
+    def test_bump_prerelease_to_stable(self, *mocks):
+        """Ensure prerelease is dropped"""
+
+        version = Version.parse("0.0.1rc1")
+        version.bump()
+
+        self.assertEquals(
+            "0.0.1",
+            str(version),
+        )
+
+    def test_is_prerelease(self, *mocks):
+        """Ensure prereleases are properly detected"""
+
+        version = Version.parse("0.0.1rc16")
+
+        self.assertEquals(
+            True,
+            version.is_prerelease,
+        )
+
+    def test_is_rc(self, *mocks):
+        """Ensure rc part of the tag flags rc"""
+
+        version = Version.parse("0.0.1rc16")
+
+        self.assertEquals(
+            True,
+            version.is_rc,
+        )
+
+    def test_is_unreleased(self, *mocks):
+        """Ensure unreleased versions are properly detected"""
+
+        version = Version.parse("66cf7c2-HEAD")
+
+        self.assertEquals(
+            False,
+            version.is_prerelease,
+        )
+
+        self.assertEquals(
+            True,
+            version.is_unreleased,
+        )
+
+    def test_parse_git(self, *mocks):
+        """parsing a version that's not an exact tag"""
+
+        version = Version.parse("TestModule/0.0.1-16-g5befeb2")
+
+        self.assertEquals(
+            "16-g5befeb2",
+            version.prerelease,
+        )
+
+        self.assertEquals(
+            Version(
+                major=0,
+                minor=0,
+                patch=1,
+                prefix="TestModule/",
+                prereleasedash="-",
+                prerelease="16-g5befeb2",
+            ),
+            version,
+        )
+
+    def test_parse_rc(self, *mocks):
+        """Ensure rc part of the tag ends up in the prerelease attr"""
+
+        version = Version.parse("0.0.1rc16")
+
+        self.assertEquals(
+            "rc16",
+            version.prerelease,
+        )
+
     def test_parse_semver(self, *mocks):
         """Ensure a basic semver is parsed"""
 
@@ -12,7 +156,7 @@ class VersionTestCase(TestCase):
         self.assertEquals(Version(major=0, minor=0, patch=1), version)
 
     def test_parse_semver_with_prefix(self, *mocks):
-        """Ensure a basic semver is parsed"""
+        """Ensure a basic semver with a prefix is parsed"""
 
         version = Version.parse("TestModule/0.0.1")
 
@@ -21,3 +165,16 @@ class VersionTestCase(TestCase):
         )
 
         self.assertEquals("TestModule/0.0.1", str(version))
+
+    def test_parse_untagged(self, *mocks):
+        """Ensure an untagged version can be parsed"""
+
+        version_s = "66cf7c2-HEAD"
+        version = Version.parse(version_s)
+
+        self.assertEquals(
+            Version(major=None, minor=None, patch=None, prerelease=version_s),
+            version,
+        )
+
+        self.assertEquals(version_s, str(version))

--- a/src/tests/test_version.py
+++ b/src/tests/test_version.py
@@ -1,0 +1,20 @@
+from unittest import TestCase, mock
+
+from tagversion.version import Version
+
+class VersionTestCase(TestCase):
+    def test_parse_semver(self, *mocks):
+        """Ensure a basic semver is parsed"""
+
+        version = Version.parse('0.0.1')
+
+        self.assertEquals(Version(major=0, minor=0, patch=1), version)
+
+    def test_parse_semver_with_prefix(self, *mocks):
+        """Ensure a basic semver is parsed"""
+
+        version = Version.parse('TestModule/0.0.1')
+
+        self.assertEquals(Version(major=0, minor=0, patch=1, prefix="TestModule/"), version)
+
+        self.assertEquals('TestModule/0.0.1', str(version))

--- a/src/tests/test_version.py
+++ b/src/tests/test_version.py
@@ -132,7 +132,7 @@ class VersionTestCase(TestCase):
                 minor=0,
                 patch=1,
                 prefix="TestModule/",
-                prereleasedash="-",
+                prerelease_separator="-",
                 prerelease="16-g5befeb2",
             ),
             version,
@@ -178,3 +178,16 @@ class VersionTestCase(TestCase):
         )
 
         self.assertEquals(version_s, str(version))
+
+    def test_stringify_json(self, *mocks):
+        """Ensure the version is returned as json"""
+        self.maxDiff = 1e6
+
+        version = Version.parse("0.0.0-6-gb57b5ca-env--dev-TestModule")
+
+        version_s = version.stringify_json()
+
+        self.assertEquals(
+            '{"version_triple": "0.0.0", "major": "0", "minor": "0", "patch": "0", "prefix": "", "prefix_separator": "", "tags": "-6-gb57b5ca-env--dev-TestModule", "prerelease": "6-gb57b5ca-env--dev-TestModule", "prerelease_separator": "-", "build": ""}',
+            version_s,
+        )

--- a/src/tests/test_version.py
+++ b/src/tests/test_version.py
@@ -193,8 +193,9 @@ class VersionTestCase(TestCase):
     def test_stringify_sugar_with_build(self, *mocks):
         """ensure the stringified version properly places the build number"""
         version = Version.parse("0.0.0-6-gb57b5ca-env--dev-TestModule")
+        version.build = "1234"
 
-        version_s = version.stringify_sugar(args=mock.Mock(build="1234"))
+        version_s = version.stringify_sugar()
 
         self.assertEquals(
             "0.0.0-1234-6-gb57b5ca-env--dev-TestModule",

--- a/src/tests/test_version.py
+++ b/src/tests/test_version.py
@@ -2,19 +2,22 @@ from unittest import TestCase, mock
 
 from tagversion.version import Version
 
+
 class VersionTestCase(TestCase):
     def test_parse_semver(self, *mocks):
         """Ensure a basic semver is parsed"""
 
-        version = Version.parse('0.0.1')
+        version = Version.parse("0.0.1")
 
         self.assertEquals(Version(major=0, minor=0, patch=1), version)
 
     def test_parse_semver_with_prefix(self, *mocks):
         """Ensure a basic semver is parsed"""
 
-        version = Version.parse('TestModule/0.0.1')
+        version = Version.parse("TestModule/0.0.1")
 
-        self.assertEquals(Version(major=0, minor=0, patch=1, prefix="TestModule/"), version)
+        self.assertEquals(
+            Version(major=0, minor=0, patch=1, prefix="TestModule/"), version
+        )
 
-        self.assertEquals('TestModule/0.0.1', str(version))
+        self.assertEquals("TestModule/0.0.1", str(version))

--- a/src/tests/test_version.py
+++ b/src/tests/test_version.py
@@ -181,13 +181,22 @@ class VersionTestCase(TestCase):
 
     def test_stringify_json(self, *mocks):
         """Ensure the version is returned as json"""
-        self.maxDiff = 1e6
-
         version = Version.parse("0.0.0-6-gb57b5ca-env--dev-TestModule")
 
         version_s = version.stringify_json()
 
         self.assertEquals(
             '{"version_triple": "0.0.0", "major": "0", "minor": "0", "patch": "0", "prefix": "", "prefix_separator": "", "tags": "-6-gb57b5ca-env--dev-TestModule", "prerelease": "6-gb57b5ca-env--dev-TestModule", "prerelease_separator": "-", "build": ""}',
+            version_s,
+        )
+
+    def test_stringify_sugar_with_build(self, *mocks):
+        """ensure the stringified version properly places the build number"""
+        version = Version.parse("0.0.0-6-gb57b5ca-env--dev-TestModule")
+
+        version_s = version.stringify_sugar(args=mock.Mock(build="1234"))
+
+        self.assertEquals(
+            "0.0.0-1234-6-gb57b5ca-env--dev-TestModule",
             version_s,
         )


### PR DESCRIPTION
Changes to support monorepo tagging and version formatting.

This PR incorporates the following changes:

- code reformatted with the `black` utility
- version processing logic refactored into a `Version` class
- a bunch more tests
- the ability to print the tag version in a couple of different formats to support some downstream use-cases.